### PR TITLE
fix for compiler-warning

### DIFF
--- a/ESPTemplateProcessor.h
+++ b/ESPTemplateProcessor.h
@@ -110,6 +110,8 @@ class ESPTemplateProcessor {
           Serial.print("Failed to process '"); Serial.print(filePath); Serial.println("': Didn't reach the end of the file.");
         }
       }
+      //this suppresses the warning 'not all control paths return a value'
+      return false;
     }
 
 


### PR DESCRIPTION
this suppresses the warning 'not all control paths return a value'